### PR TITLE
fix: moved `{String(children).replace(/\n$/, '')}` into `<SyntaxHighlighter></SyntaxHighlighter>`

### DIFF
--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -94,11 +94,12 @@ const Post: NextPage<PostProps> = ({ post }: PostProps) => {
                             const match = /language-(\w+)/.exec(className || '')
                             return !inline && match ? (
                                 <SyntaxHighlighter
-                                    children={String(children).replace(/\n$/, '')}
                                     style={vscDarkPlus}
                                     language={match[1]}
                                     PreTag="div"
-                                />
+                                >
+                                    {String(children).replace(/\n$/, '')}
+                                </SyntaxHighlighter>
                             ) : (
                                 <code className={className}>
                                     {children}


### PR DESCRIPTION
moved `{String(children).replace(/\n$/, '')}` into `<SyntaxHighlighter></SyntaxHighlighter>`